### PR TITLE
Filter enhancement

### DIFF
--- a/src/Controller/Component/FilterComponent.php
+++ b/src/Controller/Component/FilterComponent.php
@@ -70,6 +70,24 @@ class FilterComponent extends Component
     protected $sortParam;
 
     /**
+     * Holds the configured association strategy.
+     *
+     * @see FilterManager::$strategy
+     * @var string
+     */
+    protected $associationStrategy;
+
+    /**
+     * Filter query contains filterable associations
+     */
+    const FILTER_STRATEGY_CONTAIN = 'contain';
+
+    /**
+     * Filter query adds filterable associations by subqueries.
+     */
+    const FILTER_STRATEGY_SUBQUERY = 'subquery';
+
+    /**
      * Initialization hook method.
      *
      * @param array $config
@@ -135,6 +153,7 @@ class FilterComponent extends Component
         $this->limitParam = $this->getConfig($this->getAction() . '.limit.param');
         $this->pageParam = $this->getConfig($this->getAction() . '.pagination.param');
         $this->sortParam = $this->getConfig($this->getAction() . '.sort.param');
+        $this->associationStrategy = $this->getConfig($this->getAction() . '.association.strategy');
         $this->defaultSort = $this->getDefaultSort();
         $this->defaultLimit = $this->getDefaultLimit();
 
@@ -160,6 +179,7 @@ class FilterComponent extends Component
             'limitParamName' => $this->limitParam,
             'pageParamName' => $this->pageParam,
             'sortParamName' => $this->sortParam,
+            'strategy' => $this->associationStrategy,
             'handledParams' => $this->getFilterFields(),
             'allowedSortFields' => $this->getSortFields()
         ]);

--- a/src/Controller/Component/FilterComponent.php
+++ b/src/Controller/Component/FilterComponent.php
@@ -285,10 +285,46 @@ class FilterComponent extends Component
             return $url;
         }
 
+        $url = $this->_applyPassedParams($url);
+
         return $url + [
             'filterSlug' => $this->Filters->findOrCreateSlugForFilterData($this->getRequest(), $filters),
             '?' => $this->getRequest()->getQueryParams()
         ];
+    }
+
+    /**
+     * Apply configured pass params to the url array.
+     *
+     * @param array $url
+     * @return array modified url array
+     */
+    protected function _applyPassedParams($url)
+    {
+        $passParams = $this->getPassedParams();
+
+        if (empty($passParams)) {
+            return $url;
+        }
+
+        return array_merge($url, $passParams);
+    }
+
+    /**
+     * Get the passed params.
+     *
+     * @return array
+     */
+    public function getPassedParams() {
+        $passParams = [];
+        if (!empty($this->getConfig($this->getAction() . '.passParams'))) {
+            foreach ($this->getConfig($this->getAction() . '.passParams') as $key) {
+                if (!empty($this->getRequest()->getParam($key))) {
+                    $passParams[$key] = $this->getRequest()->getParam($key);
+                }
+            }
+        }
+        return $passParams;
     }
 
     /**

--- a/src/Filter/FilterHandler.php
+++ b/src/Filter/FilterHandler.php
@@ -5,6 +5,7 @@ namespace Wasabi\Core\Filter;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\Utility\Inflector;
+use Dsc\Core\Controller\Component\FilterComponent;
 use Wasabi\Core\Filter\Exception\MissingFilterMethodException;
 use Wasabi\Core\Filter\Exception\MissingSortMethodException;
 
@@ -40,11 +41,26 @@ class FilterHandler
      * Apply all filters of the filter manager to the given $query instance.
      *
      * @param Query $query
-     * @return void
+     * @return int count Count of filtered results
      * @throws MissingFilterMethodException
      */
     public function applyFilters(Query $query)
     {
+        if ($this->filterManager->getStrategy() == FilterComponent::FILTER_STRATEGY_CONTAIN) {
+            $this->_applyFilters($query);
+            return $query->count();
+        } else {
+            $idsQuery = $this->table->find()->select([$this->table->aliasField('id')]);
+
+            $this->_applyFilters($idsQuery);
+
+            $query->where([$this->table->aliasField('id') . ' IN' => $idsQuery]);
+
+            return $idsQuery->count();
+        }
+    }
+
+    protected function _applyFilters(Query $query) {
         foreach ($this->filterManager->getFilters() as $name => $value) {
             if ($value === '') {
                 continue;

--- a/src/Filter/FilterHandler.php
+++ b/src/Filter/FilterHandler.php
@@ -49,6 +49,7 @@ class FilterHandler
     {
         if ($this->filterManager->getStrategy() == FilterComponent::FILTER_STRATEGY_CONTAIN) {
             $this->_applyFilters($query);
+
             return $query->count();
         } else {
             $idsQuery = $this->table->find()->select([$this->table->aliasField('id')]);
@@ -67,7 +68,8 @@ class FilterHandler
      * @param Query $query
      * @throws MissingFilterMethodException
      */
-    protected function _applyFilters(Query $query) {
+    protected function _applyFilters(Query $query)
+    {
         foreach ($this->filterManager->getFilters() as $name => $value) {
             if ($value === '') {
                 continue;

--- a/src/Filter/FilterHandler.php
+++ b/src/Filter/FilterHandler.php
@@ -38,7 +38,8 @@ class FilterHandler
     }
 
     /**
-     * Apply all filters of the filter manager to the given $query instance.
+     * Apply all filters of the filter manager to the given $query instance based on the
+     * {@link FilterManager::getStrategy}.
      *
      * @param Query $query
      * @return int count Count of filtered results
@@ -60,6 +61,12 @@ class FilterHandler
         }
     }
 
+    /**
+     * Apply all filters of the filter manager to the given $query instance.
+     *
+     * @param Query $query
+     * @throws MissingFilterMethodException
+     */
     protected function _applyFilters(Query $query) {
         foreach ($this->filterManager->getFilters() as $name => $value) {
             if ($value === '') {

--- a/src/Filter/FilterHandler.php
+++ b/src/Filter/FilterHandler.php
@@ -110,7 +110,9 @@ class FilterHandler
      */
     public function applyPagination(Query $query)
     {
-        $query->limit($this->filterManager->getLimit());
-        $query->page($this->filterManager->getPage());
+        if ($this->filterManager->isPaginationActive()) {
+            $query->limit($this->filterManager->getLimit());
+            $query->page($this->filterManager->getPage());
+        }
     }
 }

--- a/src/Filter/FilterManager.php
+++ b/src/Filter/FilterManager.php
@@ -97,7 +97,7 @@ class FilterManager
      * @param array $params The params to be filtered on.
      * @param array $config Provides configuration options for the filter manager.
      */
-    public function __construct($params, array $config = [])
+    public function __construct(array $config = [])
     {
         $this->pageParamName = (string)Hash::get($config, 'pageParamName', 'page');
         $this->limitParamName = (string)Hash::get($config, 'limitParamName', 'limit');
@@ -105,39 +105,36 @@ class FilterManager
         $this->paramsToHandle = (array)Hash::get($config, 'handledParams', []);
         $this->paramsToIgnore = (array)Hash::get($config, 'ignoredParams', []);
         $this->strategy = (string)Hash::get($config, 'strategy', FilterComponent::FILTER_STRATEGY_CONTAIN);
+    }
 
+    /**
+     * Setup a filter for the given $params.
+     *
+     * @param string $param
+     * @param mixed $value
+     */
+    public function setupFilter($params) {
         foreach ($params as $param => $value) {
             if ($this->shouldSkipParam($param)) {
                 continue;
             }
 
-            $this->setupFilter($param, $value);
-        }
-    }
+            switch ($param) {
+                case $this->limitParamName:
+                    $this->limit = (int)$value;
+                    break;
 
-    /**
-     * Setup a filter for the given $param and $value.
-     *
-     * @param string $param
-     * @param mixed $value
-     */
-    protected function setupFilter($param, $value)
-    {
-        switch ($param) {
-            case $this->limitParamName:
-                $this->limit = (int)$value;
-                break;
+                case $this->pageParamName:
+                    $this->page = (int)$value;
+                    break;
 
-            case $this->pageParamName:
-                $this->page = (int)$value;
-                break;
+                case $this->sortParamName:
+                    $this->setupSort($value);
+                    break;
 
-            case $this->sortParamName:
-                $this->setupSort($value);
-                break;
-
-            default:
-                $this->addFilter($param, $value);
+                default:
+                    $this->addFilter($param, $value);
+            }
         }
     }
 

--- a/src/Filter/FilterManager.php
+++ b/src/Filter/FilterManager.php
@@ -84,7 +84,7 @@ class FilterManager
      *
      * Possible values are:
      *
-     * 'contain' (default) -> filter query contains filterable associations
+     * 'contain' (default) -> filter query contains filterable associations.
      * 'subquery' -> filter query adds filterable associations by subqueries.
      *
      * @var string

--- a/src/Filter/FilterManager.php
+++ b/src/Filter/FilterManager.php
@@ -73,6 +73,13 @@ class FilterManager
     private $limitParamName;
 
     /**
+     * Holds if limitation/pagination is on/off
+     *
+     * @var bool
+     */
+    private $paginationActive = true;
+
+    /**
      * Holds the sort parameter name.
      *
      * @var string
@@ -187,6 +194,26 @@ class FilterManager
     public function getLimit()
     {
         return $this->limit;
+    }
+
+    /**
+     * Is limitation/pagination on?
+     *
+     * @return bool
+     */
+    public function isPaginationActive(): bool
+    {
+        return $this->paginationActive;
+    }
+
+    /**
+     * Turns on/off limitation/pagination.
+     *
+     * @param bool $activeLimit
+     */
+    public function setPaginationActive(bool $paginationActive)
+    {
+        $this->paginationActive = $paginationActive;
     }
 
     /**

--- a/src/Filter/FilterManager.php
+++ b/src/Filter/FilterManager.php
@@ -3,6 +3,7 @@
 namespace Wasabi\Core\Filter;
 
 use Cake\Utility\Hash;
+use Wasabi\Core\Controller\Component\FilterComponent;
 
 class FilterManager
 {
@@ -79,6 +80,18 @@ class FilterManager
     private $sortParamName;
 
     /**
+     * Holds the type of strategy used for filtered associations.
+     *
+     * Possible values are:
+     *
+     * 'contain' (default) -> filter query contains filterable associations
+     * 'subquery' -> filter query adds filterable associations by subqueries.
+     *
+     * @var string
+     */
+    private $strategy;
+
+    /**
      * Constructor
      *
      * @param array $params The params to be filtered on.
@@ -91,6 +104,7 @@ class FilterManager
         $this->sortParamName = (string)Hash::get($config, 'sortParamName', 'sort');
         $this->paramsToHandle = (array)Hash::get($config, 'handledParams', []);
         $this->paramsToIgnore = (array)Hash::get($config, 'ignoredParams', []);
+        $this->strategy = (string)Hash::get($config, 'strategy', FilterComponent::FILTER_STRATEGY_CONTAIN);
 
         foreach ($params as $param => $value) {
             if ($this->shouldSkipParam($param)) {
@@ -248,6 +262,20 @@ class FilterManager
     public function getSortString()
     {
         return $this->sortString;
+    }
+
+    /**
+     * Gets the type of strategy used for filtered associations.
+     *
+     * Possible values are:
+     * 'contain' -> filter query contains filterable associations
+     * 'subquery' (default) -> filter query adds filterable associations by subqueries.
+     *
+     * @return string
+     */
+    public function getStrategy(): string
+    {
+        return $this->strategy;
     }
 
     /**

--- a/src/Filter/FilterManager.php
+++ b/src/Filter/FilterManager.php
@@ -97,7 +97,7 @@ class FilterManager
      * @param array $params The params to be filtered on.
      * @param array $config Provides configuration options for the filter manager.
      */
-    public function __construct(array $config = [])
+    public function __construct($params, array $config = [])
     {
         $this->pageParamName = (string)Hash::get($config, 'pageParamName', 'page');
         $this->limitParamName = (string)Hash::get($config, 'limitParamName', 'limit');
@@ -105,36 +105,39 @@ class FilterManager
         $this->paramsToHandle = (array)Hash::get($config, 'handledParams', []);
         $this->paramsToIgnore = (array)Hash::get($config, 'ignoredParams', []);
         $this->strategy = (string)Hash::get($config, 'strategy', FilterComponent::FILTER_STRATEGY_CONTAIN);
-    }
 
-    /**
-     * Setup a filter for the given $params.
-     *
-     * @param string $param
-     * @param mixed $value
-     */
-    public function setupFilter($params) {
         foreach ($params as $param => $value) {
             if ($this->shouldSkipParam($param)) {
                 continue;
             }
 
-            switch ($param) {
-                case $this->limitParamName:
-                    $this->limit = (int)$value;
-                    break;
+            $this->setupFilter($param, $value);
+        }
+    }
 
-                case $this->pageParamName:
-                    $this->page = (int)$value;
-                    break;
+    /**
+     * Setup a filter for the given $param and $value.
+     *
+     * @param string $param
+     * @param mixed $value
+     */
+    protected function setupFilter($param, $value)
+    {
+        switch ($param) {
+            case $this->limitParamName:
+                $this->limit = (int)$value;
+                break;
 
-                case $this->sortParamName:
-                    $this->setupSort($value);
-                    break;
+            case $this->pageParamName:
+                $this->page = (int)$value;
+                break;
 
-                default:
-                    $this->addFilter($param, $value);
-            }
+            case $this->sortParamName:
+                $this->setupSort($value);
+                break;
+
+            default:
+                $this->addFilter($param, $value);
         }
     }
 

--- a/src/Filter/Filterable.php
+++ b/src/Filter/Filterable.php
@@ -102,4 +102,18 @@ trait Filterable
             return $expression->like($field, $value, 'string');
         };
     }
+
+    /**
+     * Create a `LIKE` filter expression for the given $field and '%' . $value . '%'.
+     *
+     * @param string $field
+     * @param string $value
+     * @return \Closure
+     */
+    protected function likeContainFilter(string $field, string $value): \Closure
+    {
+        return function (QueryExpression $expression) use ($field, $value) {
+            return $expression->like($field, '%' . $value . '%', 'string');
+        };
+    }
 }

--- a/src/Filter/Filterable.php
+++ b/src/Filter/Filterable.php
@@ -21,9 +21,7 @@ trait Filterable
         /** @var Table $this */
         $filterHandler = new FilterHandler($this, $filterManager);
 
-        $idsQuery = $this->getFilteredIdsQuery($filterHandler);
-
-        $count = $idsQuery->count();
+        $count = $filterHandler->applyFilters($query);
 
         if ($count === 0) {
             $paginationData = [
@@ -37,8 +35,6 @@ trait Filterable
             /** @var Table $this */
             return new FilterResult($this->find()->select($this->aliasField('id'))->where(['1 <> 1']), $paginationData);
         }
-
-        $query->where([$this->aliasField('id') . ' IN' => $idsQuery]);
 
         $filterHandler->applySort($query);
         $filterHandler->applyPagination($query);

--- a/src/Filter/Sortable.php
+++ b/src/Filter/Sortable.php
@@ -11,7 +11,7 @@ trait Sortable
      * Apply natural asc sorting to the given $field on the $query.
      *
      * @param Query $query
-     * @param $field
+     * @param string $field
      * @return Query
      */
     protected function naturalSortAsc(Query $query, string $field): Query

--- a/src/View/Helper/FilterHelper.php
+++ b/src/View/Helper/FilterHelper.php
@@ -264,6 +264,10 @@ class FilterHelper extends Helper
             'prefix' => $this->request->getParam('prefix')
         ];
 
+        foreach($this->filterComponent->getPassedParams() as $name => $value) {
+            $url[$name] = $value;
+        }
+
         if (!empty($this->request->getParam('filterSlug'))) {
             $url['filterSlug'] = $this->request->getParam('filterSlug');
         };


### PR DESCRIPTION
Added strategies:
contain - filter query contains filterable associations
subquery - filter query adds filterable associations by subqueries
to filter mechanism.

Default is contain strategy which applies the filters directly to the main query. This works whether the user have implemented the filter methods with subqueries or as contained condition.
Strategy subquery mirrors the old behavior, where the user have to implement the association conditions as subqueries.